### PR TITLE
feat: OpenAPI reference auto generated by zod, Scalar for interactive

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -29,6 +29,7 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@cloudflare/workers-types", "npm:4.20241022.0"],\
           ["@eslint/js", "npm:9.13.0"],\
+          ["@hono/zod-openapi", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.16.4"],\
           ["@types/bcryptjs", "npm:2.4.6"],\
           ["@typescript-eslint/eslint-plugin", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
           ["@typescript-eslint/parser", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
@@ -45,9 +46,33 @@ const RAW_RUNTIME_STATE =
           ["prettier-plugin-organize-imports", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:4.1.0"],\
           ["typescript", "patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"],\
           ["vitest", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"],\
-          ["wrangler", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:3.84.1"]\
+          ["wrangler", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:3.84.1"],\
+          ["zod", "npm:3.23.8"]\
         ],\
         "linkType": "SOFT"\
+      }]\
+    ]],\
+    ["@asteasolutions/zod-to-openapi", [\
+      ["npm:7.2.0", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@asteasolutions-zod-to-openapi-npm-7.2.0-6b808ece15-10c0.zip/node_modules/@asteasolutions/zod-to-openapi/",\
+        "packageDependencies": [\
+          ["@asteasolutions/zod-to-openapi", "npm:7.2.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:307b191b202f1e27d677b393b5c74d0ef3fe874fdd42a91911232eed97f46c6a8324c61979b11bf3855092df29587640ccb9de737d596a78ab7b960cc56d0d84#npm:7.2.0", {\
+        "packageLocation": "./.yarn/__virtual__/@asteasolutions-zod-to-openapi-virtual-53a2c2335a/5/.yarn/berry/cache/@asteasolutions-zod-to-openapi-npm-7.2.0-6b808ece15-10c0.zip/node_modules/@asteasolutions/zod-to-openapi/",\
+        "packageDependencies": [\
+          ["@asteasolutions/zod-to-openapi", "virtual:307b191b202f1e27d677b393b5c74d0ef3fe874fdd42a91911232eed97f46c6a8324c61979b11bf3855092df29587640ccb9de737d596a78ab7b960cc56d0d84#npm:7.2.0"],\
+          ["@types/zod", null],\
+          ["openapi3-ts", "npm:4.4.0"],\
+          ["zod", "npm:3.23.8"]\
+        ],\
+        "packagePeers": [\
+          "@types/zod",\
+          "zod"\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@cloudflare/kv-asset-handler", [\
@@ -660,6 +685,60 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../../.yarn/berry/cache/@fastify-busboy-npm-2.1.1-455d8b6bf5-10c0.zip/node_modules/@fastify/busboy/",\
         "packageDependencies": [\
           ["@fastify/busboy", "npm:2.1.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@hono/zod-openapi", [\
+      ["npm:0.16.4", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@hono-zod-openapi-npm-0.16.4-e83af6f3bb-10c0.zip/node_modules/@hono/zod-openapi/",\
+        "packageDependencies": [\
+          ["@hono/zod-openapi", "npm:0.16.4"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.16.4", {\
+        "packageLocation": "./.yarn/__virtual__/@hono-zod-openapi-virtual-307b191b20/5/.yarn/berry/cache/@hono-zod-openapi-npm-0.16.4-e83af6f3bb-10c0.zip/node_modules/@hono/zod-openapi/",\
+        "packageDependencies": [\
+          ["@hono/zod-openapi", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.16.4"],\
+          ["@asteasolutions/zod-to-openapi", "virtual:307b191b202f1e27d677b393b5c74d0ef3fe874fdd42a91911232eed97f46c6a8324c61979b11bf3855092df29587640ccb9de737d596a78ab7b960cc56d0d84#npm:7.2.0"],\
+          ["@hono/zod-validator", "virtual:307b191b202f1e27d677b393b5c74d0ef3fe874fdd42a91911232eed97f46c6a8324c61979b11bf3855092df29587640ccb9de737d596a78ab7b960cc56d0d84#npm:0.3.0"],\
+          ["@types/hono", null],\
+          ["@types/zod", null],\
+          ["hono", "npm:4.6.8"],\
+          ["zod", "npm:3.23.8"]\
+        ],\
+        "packagePeers": [\
+          "@types/hono",\
+          "@types/zod",\
+          "hono",\
+          "zod"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@hono/zod-validator", [\
+      ["npm:0.3.0", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@hono-zod-validator-npm-0.3.0-49782454e4-10c0.zip/node_modules/@hono/zod-validator/",\
+        "packageDependencies": [\
+          ["@hono/zod-validator", "npm:0.3.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:307b191b202f1e27d677b393b5c74d0ef3fe874fdd42a91911232eed97f46c6a8324c61979b11bf3855092df29587640ccb9de737d596a78ab7b960cc56d0d84#npm:0.3.0", {\
+        "packageLocation": "./.yarn/__virtual__/@hono-zod-validator-virtual-e996722b7a/5/.yarn/berry/cache/@hono-zod-validator-npm-0.3.0-49782454e4-10c0.zip/node_modules/@hono/zod-validator/",\
+        "packageDependencies": [\
+          ["@hono/zod-validator", "virtual:307b191b202f1e27d677b393b5c74d0ef3fe874fdd42a91911232eed97f46c6a8324c61979b11bf3855092df29587640ccb9de737d596a78ab7b960cc56d0d84#npm:0.3.0"],\
+          ["@types/hono", null],\
+          ["@types/zod", null],\
+          ["hono", "npm:4.6.8"],\
+          ["zod", "npm:3.23.8"]\
+        ],\
+        "packagePeers": [\
+          "@types/hono",\
+          "@types/zod",\
+          "hono",\
+          "zod"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2874,6 +2953,7 @@ const RAW_RUNTIME_STATE =
           ["kumo-auth", "workspace:."],\
           ["@cloudflare/workers-types", "npm:4.20241022.0"],\
           ["@eslint/js", "npm:9.13.0"],\
+          ["@hono/zod-openapi", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.16.4"],\
           ["@types/bcryptjs", "npm:2.4.6"],\
           ["@typescript-eslint/eslint-plugin", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
           ["@typescript-eslint/parser", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
@@ -2890,7 +2970,8 @@ const RAW_RUNTIME_STATE =
           ["prettier-plugin-organize-imports", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:4.1.0"],\
           ["typescript", "patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"],\
           ["vitest", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"],\
-          ["wrangler", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:3.84.1"]\
+          ["wrangler", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:3.84.1"],\
+          ["zod", "npm:3.23.8"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -3356,6 +3437,16 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["onetime", "npm:7.0.0"],\
           ["mimic-function", "npm:5.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["openapi3-ts", [\
+      ["npm:4.4.0", {\
+        "packageLocation": "../../../../.yarn/berry/cache/openapi3-ts-npm-4.4.0-694442af4b-10c0.zip/node_modules/openapi3-ts/",\
+        "packageDependencies": [\
+          ["openapi3-ts", "npm:4.4.0"],\
+          ["yaml", "npm:2.6.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -4614,6 +4705,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../../.yarn/berry/cache/yaml-npm-2.5.1-8b2871f510-10c0.zip/node_modules/yaml/",\
         "packageDependencies": [\
           ["yaml", "npm:2.5.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.6.0", {\
+        "packageLocation": "../../../../.yarn/berry/cache/yaml-npm-2.6.0-1c0bd2fcf8-10c0.zip/node_modules/yaml/",\
+        "packageDependencies": [\
+          ["yaml", "npm:2.6.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -31,8 +31,10 @@ const RAW_RUNTIME_STATE =
           ["@eslint/js", "npm:9.13.0"],\
           ["@hono/zod-openapi", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.16.4"],\
           ["@types/bcryptjs", "npm:2.4.6"],\
+          ["@types/node", "npm:22.8.6"],\
           ["@typescript-eslint/eslint-plugin", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
           ["@typescript-eslint/parser", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
+          ["@vitest/ui", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"],\
           ["bad-words", "npm:4.0.0"],\
           ["bcryptjs", "npm:2.4.3"],\
           ["eslint", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:9.13.0"],\
@@ -45,6 +47,8 @@ const RAW_RUNTIME_STATE =
           ["prettier", "npm:3.3.3"],\
           ["prettier-plugin-organize-imports", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:4.1.0"],\
           ["typescript", "patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"],\
+          ["vite", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.4.10"],\
+          ["vite-tsconfig-paths", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.0.1"],\
           ["vitest", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"],\
           ["wrangler", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:3.84.1"],\
           ["zod", "npm:3.23.8"]\
@@ -907,6 +911,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@polka/url", [\
+      ["npm:1.0.0-next.28", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@polka-url-npm-1.0.0-next.28-024769eda8-10c0.zip/node_modules/@polka/url/",\
+        "packageDependencies": [\
+          ["@polka/url", "npm:1.0.0-next.28"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@rollup/rollup-android-arm-eabi", [\
       ["npm:4.24.3", {\
         "packageLocation": "./.yarn/unplugged/@rollup-rollup-android-arm-eabi-npm-4.24.3-baad4538c5/node_modules/@rollup/rollup-android-arm-eabi/",\
@@ -1101,6 +1114,14 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../../.yarn/berry/cache/@types-node-npm-22.8.5-6fb0b9e585-10c0.zip/node_modules/@types/node/",\
         "packageDependencies": [\
           ["@types/node", "npm:22.8.5"],\
+          ["undici-types", "npm:6.19.8"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:22.8.6", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@types-node-npm-22.8.6-5ae2f0b6f8-10c0.zip/node_modules/@types/node/",\
+        "packageDependencies": [\
+          ["@types/node", "npm:22.8.6"],\
           ["undici-types", "npm:6.19.8"]\
         ],\
         "linkType": "HARD"\
@@ -1368,7 +1389,7 @@ const RAW_RUNTIME_STATE =
           ["estree-walker", "npm:3.0.3"],\
           ["magic-string", "npm:0.30.12"],\
           ["msw", null],\
-          ["vite", "virtual:fd25d155f0508cfbefafec65004a66df754e6dd0d1966e5f46e0523069889e78e428d3276dc126e116b307f9d9a9b5208819852d8c6fd0e99b59950f5c75e3d8#npm:5.4.10"]\
+          ["vite", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.4.10"]\
         ],\
         "packagePeers": [\
           "@types/msw",\
@@ -1418,6 +1439,35 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@vitest/spy", "npm:2.1.4"],\
           ["tinyspy", "npm:3.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@vitest/ui", [\
+      ["npm:2.1.4", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@vitest-ui-npm-2.1.4-5b87a6442b-10c0.zip/node_modules/@vitest/ui/",\
+        "packageDependencies": [\
+          ["@vitest/ui", "npm:2.1.4"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4", {\
+        "packageLocation": "./.yarn/__virtual__/@vitest-ui-virtual-157887f001/5/.yarn/berry/cache/@vitest-ui-npm-2.1.4-5b87a6442b-10c0.zip/node_modules/@vitest/ui/",\
+        "packageDependencies": [\
+          ["@vitest/ui", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"],\
+          ["@types/vitest", null],\
+          ["@vitest/utils", "npm:2.1.4"],\
+          ["fflate", "npm:0.8.2"],\
+          ["flatted", "npm:3.3.1"],\
+          ["pathe", "npm:1.1.2"],\
+          ["sirv", "npm:3.0.0"],\
+          ["tinyglobby", "npm:0.2.10"],\
+          ["tinyrainbow", "npm:1.2.0"],\
+          ["vitest", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"]\
+        ],\
+        "packagePeers": [\
+          "@types/vitest",\
+          "vitest"\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2424,6 +2474,37 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["fdir", [\
+      ["npm:6.4.2", {\
+        "packageLocation": "../../../../.yarn/berry/cache/fdir-npm-6.4.2-83cd21b34c-10c0.zip/node_modules/fdir/",\
+        "packageDependencies": [\
+          ["fdir", "npm:6.4.2"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:70bf4c34d97020ffca942d941c43db8c9d7071127bdc95cbe7df8bb2cc59b4e2ed38df8821b6c31a1c40b77f21928e9956b146be139794ff1bd671e64b0e59c9#npm:6.4.2", {\
+        "packageLocation": "./.yarn/__virtual__/fdir-virtual-9c2d126aad/5/.yarn/berry/cache/fdir-npm-6.4.2-83cd21b34c-10c0.zip/node_modules/fdir/",\
+        "packageDependencies": [\
+          ["fdir", "virtual:70bf4c34d97020ffca942d941c43db8c9d7071127bdc95cbe7df8bb2cc59b4e2ed38df8821b6c31a1c40b77f21928e9956b146be139794ff1bd671e64b0e59c9#npm:6.4.2"],\
+          ["@types/picomatch", null],\
+          ["picomatch", "npm:4.0.2"]\
+        ],\
+        "packagePeers": [\
+          "@types/picomatch",\
+          "picomatch"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["fflate", [\
+      ["npm:0.8.2", {\
+        "packageLocation": "../../../../.yarn/berry/cache/fflate-npm-0.8.2-5129f303f0-10c0.zip/node_modules/fflate/",\
+        "packageDependencies": [\
+          ["fflate", "npm:0.8.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["file-entry-cache", [\
       ["npm:8.0.0", {\
         "packageLocation": "../../../../.yarn/berry/cache/file-entry-cache-npm-8.0.0-5b09d19a83-10c0.zip/node_modules/file-entry-cache/",\
@@ -2606,6 +2687,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../../.yarn/berry/cache/globals-npm-15.11.0-336de1c0c2-10c0.zip/node_modules/globals/",\
         "packageDependencies": [\
           ["globals", "npm:15.11.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["globrex", [\
+      ["npm:0.1.2", {\
+        "packageLocation": "../../../../.yarn/berry/cache/globrex-npm-0.1.2-ddda94f2d0-10c0.zip/node_modules/globrex/",\
+        "packageDependencies": [\
+          ["globrex", "npm:0.1.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2955,8 +3045,10 @@ const RAW_RUNTIME_STATE =
           ["@eslint/js", "npm:9.13.0"],\
           ["@hono/zod-openapi", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.16.4"],\
           ["@types/bcryptjs", "npm:2.4.6"],\
+          ["@types/node", "npm:22.8.6"],\
           ["@typescript-eslint/eslint-plugin", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
           ["@typescript-eslint/parser", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
+          ["@vitest/ui", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"],\
           ["bad-words", "npm:4.0.0"],\
           ["bcryptjs", "npm:2.4.3"],\
           ["eslint", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:9.13.0"],\
@@ -2969,6 +3061,8 @@ const RAW_RUNTIME_STATE =
           ["prettier", "npm:3.3.3"],\
           ["prettier-plugin-organize-imports", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:4.1.0"],\
           ["typescript", "patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"],\
+          ["vite", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.4.10"],\
+          ["vite-tsconfig-paths", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.0.1"],\
           ["vitest", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"],\
           ["wrangler", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:3.84.1"],\
           ["zod", "npm:3.23.8"]\
@@ -3312,6 +3406,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["mrmime", [\
+      ["npm:2.0.0", {\
+        "packageLocation": "../../../../.yarn/berry/cache/mrmime-npm-2.0.0-0326eb1458-10c0.zip/node_modules/mrmime/",\
+        "packageDependencies": [\
+          ["mrmime", "npm:2.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["ms", [\
       ["npm:2.1.3", {\
         "packageLocation": "../../../../.yarn/berry/cache/ms-npm-2.1.3-81ff3cfac1-10c0.zip/node_modules/ms/",\
@@ -3601,6 +3704,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../../.yarn/berry/cache/picomatch-npm-2.3.1-c782cfd986-10c0.zip/node_modules/picomatch/",\
         "packageDependencies": [\
           ["picomatch", "npm:2.3.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:4.0.2", {\
+        "packageLocation": "../../../../.yarn/berry/cache/picomatch-npm-4.0.2-e93516ddf2-10c0.zip/node_modules/picomatch/",\
+        "packageDependencies": [\
+          ["picomatch", "npm:4.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -3946,6 +4056,18 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["sirv", [\
+      ["npm:3.0.0", {\
+        "packageLocation": "../../../../.yarn/berry/cache/sirv-npm-3.0.0-5773cccdab-10c0.zip/node_modules/sirv/",\
+        "packageDependencies": [\
+          ["sirv", "npm:3.0.0"],\
+          ["@polka/url", "npm:1.0.0-next.28"],\
+          ["mrmime", "npm:2.0.0"],\
+          ["totalist", "npm:3.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["slice-ansi", [\
       ["npm:5.0.0", {\
         "packageLocation": "../../../../.yarn/berry/cache/slice-ansi-npm-5.0.0-8cd4f226df-10c0.zip/node_modules/slice-ansi/",\
@@ -4231,6 +4353,17 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["tinyglobby", [\
+      ["npm:0.2.10", {\
+        "packageLocation": "../../../../.yarn/berry/cache/tinyglobby-npm-0.2.10-70bf4c34d9-10c0.zip/node_modules/tinyglobby/",\
+        "packageDependencies": [\
+          ["tinyglobby", "npm:0.2.10"],\
+          ["fdir", "virtual:70bf4c34d97020ffca942d941c43db8c9d7071127bdc95cbe7df8bb2cc59b4e2ed38df8821b6c31a1c40b77f21928e9956b146be139794ff1bd671e64b0e59c9#npm:6.4.2"],\
+          ["picomatch", "npm:4.0.2"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["tinypool", [\
       ["npm:1.0.1", {\
         "packageLocation": "../../../../.yarn/berry/cache/tinypool-npm-1.0.1-d26e93a818-10c0.zip/node_modules/tinypool/",\
@@ -4268,6 +4401,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["totalist", [\
+      ["npm:3.0.1", {\
+        "packageLocation": "../../../../.yarn/berry/cache/totalist-npm-3.0.1-91e71f3baa-10c0.zip/node_modules/totalist/",\
+        "packageDependencies": [\
+          ["totalist", "npm:3.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["ts-api-utils", [\
       ["npm:1.4.0", {\
         "packageLocation": "../../../../.yarn/berry/cache/ts-api-utils-npm-1.4.0-b091964d6e-10c0.zip/node_modules/ts-api-utils/",\
@@ -4293,6 +4435,28 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/ts-api-utils-virtual-b1d0faeea2/5/.yarn/berry/cache/ts-api-utils-npm-1.4.0-b091964d6e-10c0.zip/node_modules/ts-api-utils/",\
         "packageDependencies": [\
           ["ts-api-utils", "virtual:5822e262aa963088ec05a9746ae31da883091f2296e376c752bc6185c0e21f7a3d6bf1420be5190edc1c7b298683c35014980fcfc0a49768ba37c72b97e47bb4#npm:1.4.0"],\
+          ["@types/typescript", null],\
+          ["typescript", null]\
+        ],\
+        "packagePeers": [\
+          "@types/typescript",\
+          "typescript"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["tsconfck", [\
+      ["npm:3.1.4", {\
+        "packageLocation": "../../../../.yarn/berry/cache/tsconfck-npm-3.1.4-93bca97b83-10c0.zip/node_modules/tsconfck/",\
+        "packageDependencies": [\
+          ["tsconfck", "npm:3.1.4"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:fbc1e4a725c8962a2cafaed7bd0a797a46126364d4e05da6a4fc343bb38b1d04cf1472b46d2e70521851046d531e45490060a39828b10d1c37756d595aacad4f#npm:3.1.4", {\
+        "packageLocation": "./.yarn/__virtual__/tsconfck-virtual-4832ef09e7/5/.yarn/berry/cache/tsconfck-npm-3.1.4-93bca97b83-10c0.zip/node_modules/tsconfck/",\
+        "packageDependencies": [\
+          ["tsconfck", "virtual:fbc1e4a725c8962a2cafaed7bd0a797a46126364d4e05da6a4fc343bb38b1d04cf1472b46d2e70521851046d531e45490060a39828b10d1c37756d595aacad4f#npm:3.1.4"],\
           ["@types/typescript", null],\
           ["typescript", null]\
         ],\
@@ -4410,6 +4574,49 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
+      ["virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.4.10", {\
+        "packageLocation": "./.yarn/__virtual__/vite-virtual-831acd9201/5/.yarn/berry/cache/vite-npm-5.4.10-30d2e3a4e2-10c0.zip/node_modules/vite/",\
+        "packageDependencies": [\
+          ["vite", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.4.10"],\
+          ["@types/less", null],\
+          ["@types/lightningcss", null],\
+          ["@types/node", "npm:22.8.6"],\
+          ["@types/sass", null],\
+          ["@types/sass-embedded", null],\
+          ["@types/stylus", null],\
+          ["@types/sugarss", null],\
+          ["@types/terser", null],\
+          ["esbuild", "npm:0.21.5"],\
+          ["fsevents", "patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"],\
+          ["less", null],\
+          ["lightningcss", null],\
+          ["postcss", "npm:8.4.47"],\
+          ["rollup", "npm:4.24.3"],\
+          ["sass", null],\
+          ["sass-embedded", null],\
+          ["stylus", null],\
+          ["sugarss", null],\
+          ["terser", null]\
+        ],\
+        "packagePeers": [\
+          "@types/less",\
+          "@types/lightningcss",\
+          "@types/node",\
+          "@types/sass-embedded",\
+          "@types/sass",\
+          "@types/stylus",\
+          "@types/sugarss",\
+          "@types/terser",\
+          "less",\
+          "lightningcss",\
+          "sass-embedded",\
+          "sass",\
+          "stylus",\
+          "sugarss",\
+          "terser"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:fd25d155f0508cfbefafec65004a66df754e6dd0d1966e5f46e0523069889e78e428d3276dc126e116b307f9d9a9b5208819852d8c6fd0e99b59950f5c75e3d8#npm:5.4.10", {\
         "packageLocation": "./.yarn/__virtual__/vite-virtual-9ca46cabd3/5/.yarn/berry/cache/vite-npm-5.4.10-30d2e3a4e2-10c0.zip/node_modules/vite/",\
         "packageDependencies": [\
@@ -4467,6 +4674,31 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["vite-tsconfig-paths", [\
+      ["npm:5.0.1", {\
+        "packageLocation": "../../../../.yarn/berry/cache/vite-tsconfig-paths-npm-5.0.1-a4cd1cbcaf-10c0.zip/node_modules/vite-tsconfig-paths/",\
+        "packageDependencies": [\
+          ["vite-tsconfig-paths", "npm:5.0.1"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.0.1", {\
+        "packageLocation": "./.yarn/__virtual__/vite-tsconfig-paths-virtual-fbc1e4a725/5/.yarn/berry/cache/vite-tsconfig-paths-npm-5.0.1-a4cd1cbcaf-10c0.zip/node_modules/vite-tsconfig-paths/",\
+        "packageDependencies": [\
+          ["vite-tsconfig-paths", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.0.1"],\
+          ["@types/vite", null],\
+          ["debug", "virtual:3374e8211c8552bd058409bb32829cbe46011ae75cade0b7d3d3c8d8aee68ec5a04759a8ab9d63ecd59d990daccdb9f7d444ca14945f7174d7868d5c95c99333#npm:4.3.7"],\
+          ["globrex", "npm:0.1.2"],\
+          ["tsconfck", "virtual:fbc1e4a725c8962a2cafaed7bd0a797a46126364d4e05da6a4fc343bb38b1d04cf1472b46d2e70521851046d531e45490060a39828b10d1c37756d595aacad4f#npm:3.1.4"],\
+          ["vite", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.4.10"]\
+        ],\
+        "packagePeers": [\
+          "@types/vite",\
+          "vite"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["vitest", [\
       ["npm:2.1.4", {\
         "packageLocation": "../../../../.yarn/berry/cache/vitest-npm-2.1.4-4b3692c685-10c0.zip/node_modules/vitest/",\
@@ -4483,7 +4715,7 @@ const RAW_RUNTIME_STATE =
           ["@types/edge-runtime__vm", null],\
           ["@types/happy-dom", null],\
           ["@types/jsdom", null],\
-          ["@types/node", null],\
+          ["@types/node", "npm:22.8.6"],\
           ["@types/vitest__browser", null],\
           ["@types/vitest__ui", null],\
           ["@vitest/browser", null],\
@@ -4493,7 +4725,7 @@ const RAW_RUNTIME_STATE =
           ["@vitest/runner", "npm:2.1.4"],\
           ["@vitest/snapshot", "npm:2.1.4"],\
           ["@vitest/spy", "npm:2.1.4"],\
-          ["@vitest/ui", null],\
+          ["@vitest/ui", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:2.1.4"],\
           ["@vitest/utils", "npm:2.1.4"],\
           ["chai", "npm:5.1.2"],\
           ["debug", "virtual:3374e8211c8552bd058409bb32829cbe46011ae75cade0b7d3d3c8d8aee68ec5a04759a8ab9d63ecd59d990daccdb9f7d444ca14945f7174d7868d5c95c99333#npm:4.3.7"],\
@@ -4507,7 +4739,7 @@ const RAW_RUNTIME_STATE =
           ["tinyexec", "npm:0.3.1"],\
           ["tinypool", "npm:1.0.1"],\
           ["tinyrainbow", "npm:1.2.0"],\
-          ["vite", "virtual:fd25d155f0508cfbefafec65004a66df754e6dd0d1966e5f46e0523069889e78e428d3276dc126e116b307f9d9a9b5208819852d8c6fd0e99b59950f5c75e3d8#npm:5.4.10"],\
+          ["vite", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:5.4.10"],\
           ["vite-node", "npm:2.1.4"],\
           ["why-is-node-running", "npm:2.3.0"]\
         ],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -30,6 +30,7 @@ const RAW_RUNTIME_STATE =
           ["@cloudflare/workers-types", "npm:4.20241022.0"],\
           ["@eslint/js", "npm:9.13.0"],\
           ["@hono/zod-openapi", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.16.4"],\
+          ["@scalar/hono-api-reference", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.5.158"],\
           ["@types/bcryptjs", "npm:2.4.6"],\
           ["@types/node", "npm:22.8.6"],\
           ["@typescript-eslint/eslint-plugin", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
@@ -1082,6 +1083,49 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["@scalar/hono-api-reference", [\
+      ["npm:0.5.158", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@scalar-hono-api-reference-npm-0.5.158-1a370e7590-10c0.zip/node_modules/@scalar/hono-api-reference/",\
+        "packageDependencies": [\
+          ["@scalar/hono-api-reference", "npm:0.5.158"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.5.158", {\
+        "packageLocation": "./.yarn/__virtual__/@scalar-hono-api-reference-virtual-7a3ac56a88/5/.yarn/berry/cache/@scalar-hono-api-reference-npm-0.5.158-1a370e7590-10c0.zip/node_modules/@scalar/hono-api-reference/",\
+        "packageDependencies": [\
+          ["@scalar/hono-api-reference", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.5.158"],\
+          ["@scalar/types", "npm:0.0.18"],\
+          ["@types/hono", null],\
+          ["hono", "npm:4.6.8"]\
+        ],\
+        "packagePeers": [\
+          "@types/hono",\
+          "hono"\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@scalar/openapi-types", [\
+      ["npm:0.1.4", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@scalar-openapi-types-npm-0.1.4-b778f26a3d-10c0.zip/node_modules/@scalar/openapi-types/",\
+        "packageDependencies": [\
+          ["@scalar/openapi-types", "npm:0.1.4"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@scalar/types", [\
+      ["npm:0.0.18", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@scalar-types-npm-0.0.18-90fe751536-10c0.zip/node_modules/@scalar/types/",\
+        "packageDependencies": [\
+          ["@scalar/types", "npm:0.0.18"],\
+          ["@scalar/openapi-types", "npm:0.1.4"],\
+          ["@unhead/schema", "npm:1.11.10"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["@types/bcryptjs", [\
       ["npm:2.4.6", {\
         "packageLocation": "../../../../.yarn/berry/cache/@types-bcryptjs-npm-2.4.6-50588b8234-10c0.zip/node_modules/@types/bcryptjs/",\
@@ -1354,6 +1398,17 @@ const RAW_RUNTIME_STATE =
           ["@typescript-eslint/visitor-keys", "npm:8.12.2"],\
           ["@typescript-eslint/types", "npm:8.12.2"],\
           ["eslint-visitor-keys", "npm:3.4.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["@unhead/schema", [\
+      ["npm:1.11.10", {\
+        "packageLocation": "../../../../.yarn/berry/cache/@unhead-schema-npm-1.11.10-fa4e236f26-10c0.zip/node_modules/@unhead/schema/",\
+        "packageDependencies": [\
+          ["@unhead/schema", "npm:1.11.10"],\
+          ["hookable", "npm:5.5.3"],\
+          ["zhead", "npm:2.2.4"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -2746,6 +2801,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["hookable", [\
+      ["npm:5.5.3", {\
+        "packageLocation": "../../../../.yarn/berry/cache/hookable-npm-5.5.3-82b0342097-10c0.zip/node_modules/hookable/",\
+        "packageDependencies": [\
+          ["hookable", "npm:5.5.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["http-cache-semantics", [\
       ["npm:4.1.1", {\
         "packageLocation": "../../../../.yarn/berry/cache/http-cache-semantics-npm-4.1.1-1120131375-10c0.zip/node_modules/http-cache-semantics/",\
@@ -3044,6 +3108,7 @@ const RAW_RUNTIME_STATE =
           ["@cloudflare/workers-types", "npm:4.20241022.0"],\
           ["@eslint/js", "npm:9.13.0"],\
           ["@hono/zod-openapi", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.16.4"],\
+          ["@scalar/hono-api-reference", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:0.5.158"],\
           ["@types/bcryptjs", "npm:2.4.6"],\
           ["@types/node", "npm:22.8.6"],\
           ["@typescript-eslint/eslint-plugin", "virtual:88d926bdfe94c1ba9790213eef6b6b37370078ca639b620084f8b9fcefe78a19079700cc479655b7a03e164930742750ad687bb0588703fb50e419f6a2de66a5#npm:8.12.2"],\
@@ -4965,6 +5030,15 @@ const RAW_RUNTIME_STATE =
           ["cookie", "npm:0.7.2"],\
           ["mustache", "npm:4.2.0"],\
           ["stacktracey", "npm:2.1.8"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["zhead", [\
+      ["npm:2.2.4", {\
+        "packageLocation": "../../../../.yarn/berry/cache/zhead-npm-2.2.4-1c1f24fa20-10c0.zip/node_modules/zhead/",\
+        "packageDependencies": [\
+          ["zhead", "npm:2.2.4"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["arcanis.vscode-zipfs", "esbenp.prettier-vscode"]
+  "recommendations": [
+    "arcanis.vscode-zipfs",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
   "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs",
   "typescript.tsdk": ".yarn/sdks/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "prettier.requireConfig": true
+  "prettier.requireConfig": true,
+  "eslint.nodePath": ".yarn/sdks"
 }

--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@
 │   │   └── verify.ts         # 2FA 验证（开发中）
 │   ├── index.ts              # 主入口文件，初始化 Hono 应用
 │   └── utils
-│       ├── hash.ts           # 密码加密工具
-│       └── jwt.ts            # JWT 生成和验证
+│   │   ├── hash.ts           # 密码加密工具
+│   │   └── jwt.ts            # JWT 生成和验证
+│   └── lib
+│       ├── db                # 数据库操作
+│       └── helper            # 一些数据构建
 ├── wrangler.toml             # Wrangler 配置文件
 ├── package.json              # 项目依赖和脚本
 ├── example.env               # 环境变量示例文件

--- a/README_EN.md
+++ b/README_EN.md
@@ -41,8 +41,11 @@ Designed for small applications and personal projects, this system provides a se
 │   │   └── verify.ts         # 2FA verification (in development)
 │   ├── index.ts              # Main entry, initializes Hono app
 │   └── utils
-│       ├── hash.ts           # Password hashing utilities
-│       └── jwt.ts            # JWT generation and verification
+│   │   ├── hash.ts           # Password hashing utilities
+│   │   └── jwt.ts            # JWT generation and verification
+│   └── lib
+│       ├── db                # Database query
+│       └── helper            # Data structure builder
 ├── wrangler.toml             # Wrangler configuration file
 ├── package.json              # Project dependencies and scripts
 ├── example.env               # Environment variable sample file

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     ]
   },
   "dependencies": {
+    "@hono/zod-openapi": "^0.16.4",
     "bad-words": "^4.0.0",
     "bcryptjs": "^2.4.3",
-    "hono": "^4.6.8"
+    "hono": "^4.6.8",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241022.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint src/**/*.{js,mjs,cjs,ts,tsx} --fix",
-    "test": "vitest",
+    "test": "vitest --ui",
     "test:ci": "vitest run",
     "dev": "wrangler dev",
     "deploy": "wrangler deploy --minify",
@@ -21,14 +21,17 @@
     "bad-words": "^4.0.0",
     "bcryptjs": "^2.4.3",
     "hono": "^4.6.8",
+    "vite-tsconfig-paths": "^5.0.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241022.0",
     "@eslint/js": "^9.13.0",
     "@types/bcryptjs": "^2",
+    "@types/node": "^22.8.6",
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "@typescript-eslint/parser": "^8.12.2",
+    "@vitest/ui": "2.1.4",
     "eslint": "^9.13.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
@@ -38,6 +41,7 @@
     "prettier": "3.3.3",
     "prettier-plugin-organize-imports": "^4.1.0",
     "typescript": "^5.6.3",
+    "vite": "^5.4.10",
     "vitest": "^2.1.4",
     "wrangler": "^3.84.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "^0.16.4",
+    "@scalar/hono-api-reference": "^0.5.158",
     "bad-words": "^4.0.0",
     "bcryptjs": "^2.4.3",
     "hono": "^4.6.8",

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -1,34 +1,60 @@
+import { getUserByUsername } from '@/lib/db'
+import { errorResponse, jsonContent, jsonContentRequired } from '@/lib/helper'
 import { verifyPassword } from '@/utils/hash'
 import { generateJWT } from '@/utils/jwt'
+import { createRoute, z } from '@hono/zod-openapi'
 import type { Context } from 'hono'
+
+// Define the schema for the login request
+const loginSchema = z.object({
+  username: z.string().openapi({ example: 'username' }),
+  password: z.string().openapi({ example: '123goodPassword' }),
+})
+
+// Define the response schemas for the login route
+const loginSuccessResponseSchema = z.object({
+  token: z
+    .string()
+    .openapi({ example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' }),
+})
+
+// Define the route
+export const loginRoute = createRoute({
+  method: 'post',
+  path: '/auth/login',
+  request: {
+    body: jsonContentRequired(loginSchema, 'Login request'),
+  },
+  responses: {
+    200: jsonContent(loginSuccessResponseSchema, 'Login successful'),
+    404: errorResponse('User not found'),
+    401: errorResponse('Invalid password'),
+  },
+})
 
 export const loginHandler = async (c: Context) => {
   const { username, password } = await c.req.json()
 
   // Get the user from the database
-  const db = c.env.DB // Cloudflare D1
-  const user = await db
-    .prepare('SELECT * FROM users WHERE username = ?')
-    .bind(username)
-    .first()
+  const user = await getUserByUsername(c.env.DB, username)
 
   if (!user) {
-    return c.json({ message: 'User not found' }, { status: 404 })
+    return c.json({ error: 'User not found' }, 404)
   }
 
   // Verify the password
   const isPasswordValid = await verifyPassword(password, user.password_hash)
 
   if (!isPasswordValid) {
-    return c.json({ message: 'Invalid password' }, { status: 401 })
+    return c.json({ error: 'Invalid password' }, 401)
   }
 
   // Generate a JWT token
   const token = await generateJWT(c, {
     userID: user.user_id,
-    userRole: user.user_role,
+    userRole: user.user_role_id,
     exp: Math.floor(Date.now() / 1000) + 60 * 60, // 1 hour
   })
 
-  return c.json({ token })
+  return c.json({ token }, 200)
 }

--- a/src/auth/register.test.ts
+++ b/src/auth/register.test.ts
@@ -74,7 +74,7 @@ describe('registerHandler', () => {
         role: 1,
         token: 'test.jwt.token',
       },
-      { status: 201 }
+      201
     )
   })
 
@@ -89,7 +89,7 @@ describe('registerHandler', () => {
 
     expect(mockContext.json).toHaveBeenCalledWith(
       { error: 'Invalid username' },
-      { status: 400 }
+      400
     )
   })
 
@@ -105,7 +105,7 @@ describe('registerHandler', () => {
 
     expect(mockContext.json).toHaveBeenCalledWith(
       { error: 'Invalid password' },
-      { status: 400 }
+      400
     )
   })
 })

--- a/src/auth/register.test.ts
+++ b/src/auth/register.test.ts
@@ -1,0 +1,104 @@
+import { registerHandler } from '@/auth/register'
+import type { Context } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock dependencies
+import { hashPassword } from '@/utils/hash'
+import { generateJWT } from '@/utils/jwt'
+import { passwordValidator } from '@/utils/passwordValidator'
+import { usernameValidator } from '@/utils/usernameValidator'
+
+// Mock implementations
+vi.mock('@/utils/hash')
+vi.mock('@/utils/jwt')
+vi.mock('@/utils/passwordValidator')
+vi.mock('@/utils/usernameValidator')
+
+// Mock database
+const mockDB = {
+  prepare: vi.fn().mockReturnThis(),
+  bind: vi.fn().mockReturnThis(),
+  run: vi.fn(),
+  first: vi.fn(),
+}
+
+// Mock Context
+const mockContext = {
+  env: { DB: mockDB },
+  req: { json: vi.fn().mockResolvedValueOnce({}) },
+  json: vi.fn(),
+} as unknown as Context
+
+describe('registerHandler', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    vi.clearAllMocks()
+  })
+
+  it('should register a user and return a JWT token', async () => {
+    // Set up mocks
+    mockContext.req.json = vi.fn().mockResolvedValueOnce({
+      username: 'newUser',
+      password: 'ValidPassword123!',
+    })
+    vi.mocked(usernameValidator).mockResolvedValueOnce(null) // Valid username
+    vi.mocked(passwordValidator).mockResolvedValueOnce(null) // Valid password
+    vi.mocked(hashPassword).mockResolvedValueOnce('hashedPassword')
+    mockDB.run.mockResolvedValueOnce({ lastInsertRowId: 1 }) // Simulate DB insert
+    mockDB.first.mockResolvedValueOnce({
+      user_id: 1,
+      username: 'newUser',
+      user_role_id: 1,
+    })
+    vi.mocked(generateJWT).mockResolvedValueOnce('test.jwt.token')
+
+    // Call handler
+    await registerHandler(mockContext)
+
+    // Check assertions
+    expect(mockDB.prepare).toHaveBeenCalledWith(
+      'INSERT INTO users (username, password_hash) VALUES (?, ?)'
+    )
+    expect(mockDB.bind).toHaveBeenCalledWith('newUser', 'hashedPassword')
+    expect(mockContext.json).toHaveBeenCalledWith({
+      message: 'User registered successfully',
+      data: {
+        id: 1,
+        username: 'newUser',
+        role: 1,
+        token: 'test.jwt.token',
+      },
+    })
+  })
+
+  it('should return an error if username validation fails', async () => {
+    mockContext.req.json = vi.fn().mockResolvedValueOnce({
+      username: 'badUser',
+      password: 'ValidPassword123!',
+    })
+    vi.mocked(usernameValidator).mockResolvedValueOnce('Invalid username')
+
+    await registerHandler(mockContext)
+
+    expect(mockContext.json).toHaveBeenCalledWith(
+      { error: 'Invalid username' },
+      { status: 400 }
+    )
+  })
+
+  it('should return an error if password validation fails', async () => {
+    mockContext.req.json = vi.fn().mockResolvedValueOnce({
+      username: 'newUser',
+      password: 'badPass',
+    })
+    vi.mocked(usernameValidator).mockResolvedValueOnce(null)
+    vi.mocked(passwordValidator).mockResolvedValueOnce('Invalid password')
+
+    await registerHandler(mockContext)
+
+    expect(mockContext.json).toHaveBeenCalledWith(
+      { error: 'Invalid password' },
+      { status: 400 }
+    )
+  })
+})

--- a/src/auth/register.ts
+++ b/src/auth/register.ts
@@ -10,13 +10,13 @@ export const registerHandler = async (c: Context) => {
   // Username validation
   const usernameError = await usernameValidator(c, username)
   if (usernameError) {
-    return c.json({ error: usernameError }, { status: 400 })
+    return c.json({ error: usernameError }, 400)
   }
 
   // Password validation
   const validatorError = await passwordValidator(c, password)
   if (validatorError) {
-    return c.json({ error: validatorError }, { status: 400 })
+    return c.json({ error: validatorError }, 400)
   }
 
   // Hash password and insert user into DB
@@ -28,7 +28,7 @@ export const registerHandler = async (c: Context) => {
     .run()
 
   if (!result || !result.meta.last_row_id) {
-    return c.json({ error: 'User registration failed' }, { status: 500 })
+    return c.json({ error: 'User registration failed' }, 500)
   }
 
   const user = await db
@@ -37,7 +37,7 @@ export const registerHandler = async (c: Context) => {
     .first()
 
   if (!user) {
-    return c.json({ error: 'User retrieval failed' }, { status: 500 })
+    return c.json({ error: 'User retrieval failed' }, 500)
   }
 
   // Generate JWT
@@ -54,6 +54,6 @@ export const registerHandler = async (c: Context) => {
       role: user.user_role_id,
       token,
     },
-    { status: 201 }
+    201
   )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
-import { loginHandler } from '@/auth/login'
+import { loginHandler, loginRoute } from '@/auth/login'
 import { registerHandler } from '@/auth/register'
+import { OpenAPIHono } from '@hono/zod-openapi'
+import { apiReference } from '@scalar/hono-api-reference'
 import type { Context } from 'hono'
-import { Hono } from 'hono'
 
-const app = new Hono()
+const app = new OpenAPIHono()
 
 // Home route
 app.get('/', (c: Context) => {
@@ -11,8 +12,37 @@ app.get('/', (c: Context) => {
 })
 
 // Login route
-app.post('auth/login', loginHandler)
+app.openapi(loginRoute, loginHandler)
 
 app.post('auth/register', registerHandler)
+
+// Set OpenAPI documentation
+app.doc31('/doc', {
+  openapi: '3.1.0',
+  info: {
+    title: 'KumoAuth API',
+    version: '1.0.0',
+  },
+})
+
+// Interactive API reference
+app.get(
+  '/reference',
+  apiReference({
+    pageTitle: 'KumoAuth API Reference',
+    favicon: 'https://zla.app/favicon.ico',
+    metaData: {
+      title: 'KumoAuth API Reference',
+      description: 'API reference for KumoAuth',
+      ogDescription: 'API reference for KumoAuth',
+      ogTitle: 'KumoAuth API Reference',
+    },
+    theme: 'kepler',
+    hideModels: true,
+    spec: {
+      url: '/doc',
+    },
+  })
+)
 
 export default app

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { loginHandler, loginRoute } from '@/auth/login'
-import { registerHandler } from '@/auth/register'
+import { registerHandler, registerRoute } from '@/auth/register'
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { apiReference } from '@scalar/hono-api-reference'
 import type { Context } from 'hono'
@@ -14,7 +14,7 @@ app.get('/', (c: Context) => {
 // Login route
 app.openapi(loginRoute, loginHandler)
 
-app.post('auth/register', registerHandler)
+app.openapi(registerRoute, registerHandler)
 
 // Set OpenAPI documentation
 app.doc31('/doc', {

--- a/src/lib/db/getPasswordRole.ts
+++ b/src/lib/db/getPasswordRole.ts
@@ -1,0 +1,16 @@
+import type { DBType, PasswordRule } from './types'
+
+export const getPasswordRoleByUserRoleId = async (
+  db: DBType,
+  userRoleId: number
+): Promise<PasswordRule | undefined | null> => {
+  return await db
+    .prepare(
+      `SELECT min_length, min_type, require_special, require_upper, require_number
+       FROM PasswordRules
+       JOIN UserRoles ON UserRoles.password_rule_id = PasswordRules.id
+       WHERE UserRoles.id = ?`
+    )
+    .bind(userRoleId)
+    .first()
+}

--- a/src/lib/db/getUser.ts
+++ b/src/lib/db/getUser.ts
@@ -1,0 +1,11 @@
+import type { DBType, User } from './types'
+
+export const getUserByUsername = async (
+  db: DBType,
+  username: string
+): Promise<User | undefined | null> => {
+  return await db
+    .prepare('SELECT * FROM users WHERE username = ?')
+    .bind(username)
+    .first()
+}

--- a/src/lib/db/getUser.ts
+++ b/src/lib/db/getUser.ts
@@ -9,3 +9,13 @@ export const getUserByUsername = async (
     .bind(username)
     .first()
 }
+
+export const getUserByUserId = async (
+  db: DBType,
+  user_id: number
+): Promise<User | undefined | null> => {
+  return await db
+    .prepare('SELECT * FROM users WHERE user_id = ?')
+    .bind(user_id)
+    .first()
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,1 +1,3 @@
-export { getUserByUsername } from './getUser'
+export { getPasswordRoleByUserRoleId } from './getPasswordRole'
+export { getUserByUserId, getUserByUsername } from './getUser'
+export { createNewUser } from './setUser'

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -1,0 +1,1 @@
+export { getUserByUsername } from './getUser'

--- a/src/lib/db/setUser.ts
+++ b/src/lib/db/setUser.ts
@@ -1,0 +1,12 @@
+import type { DBType, UserQueryResult } from './types'
+
+export const createNewUser = async (
+  db: DBType,
+  username: string,
+  hashedPassword: string
+): Promise<UserQueryResult | undefined | null> => {
+  return await db
+    .prepare('INSERT INTO users (username, password_hash) VALUES (?, ?)')
+    .bind(username, hashedPassword)
+    .run()
+}

--- a/src/lib/db/types.d.ts
+++ b/src/lib/db/types.d.ts
@@ -1,0 +1,28 @@
+import type { D1Database } from '@cloudflare/workers-types'
+
+export type DBType = D1Database
+
+export type User = {
+  user_id: number // main key
+  username: string
+  user_role_id: number // foreign key to UserRole
+  password_hash: string
+  created_at: string
+}
+
+export type UserRole = {
+  id: number // main key
+  role_name: string
+  password_rule_id: number // foreign key to PasswordRule
+}
+
+export type PasswordRule = {
+  id: number // main key
+  min_length: number
+  min_type: number
+  require_special: boolean
+  require_upper: boolean
+  require_number: boolean
+  created_at: string
+  updated_at: string
+}

--- a/src/lib/db/types.d.ts
+++ b/src/lib/db/types.d.ts
@@ -26,3 +26,9 @@ export type PasswordRule = {
   created_at: string
   updated_at: string
 }
+
+export type UserQueryResult = {
+  meta: {
+    last_row_id: number
+  }
+}

--- a/src/lib/helper/errorResponse.ts
+++ b/src/lib/helper/errorResponse.ts
@@ -1,0 +1,11 @@
+import { z } from '@hono/zod-openapi'
+import { jsonContent } from './jsonContent'
+
+export const errorResponse = (message: string) => {
+  return jsonContent(
+    z.object({
+      error: z.string().openapi({ example: message }),
+    }),
+    message
+  )
+}

--- a/src/lib/helper/index.ts
+++ b/src/lib/helper/index.ts
@@ -1,0 +1,4 @@
+export { errorResponse } from './errorResponse'
+export { jsonContent } from './jsonContent'
+export { jsonContentRequired } from './jsonContentRequired'
+export { jsonError } from './jsonError'

--- a/src/lib/helper/index.ts
+++ b/src/lib/helper/index.ts
@@ -1,4 +1,3 @@
 export { errorResponse } from './errorResponse'
 export { jsonContent } from './jsonContent'
 export { jsonContentRequired } from './jsonContentRequired'
-export { jsonError } from './jsonError'

--- a/src/lib/helper/jsonContent.ts
+++ b/src/lib/helper/jsonContent.ts
@@ -1,0 +1,15 @@
+import type { ZodSchema } from './types'
+
+export const jsonContent = <T extends ZodSchema>(
+  schema: T,
+  description: string
+) => {
+  return {
+    content: {
+      'application/json': {
+        schema: schema,
+      },
+    },
+    description: description,
+  }
+}

--- a/src/lib/helper/jsonContentRequired.ts
+++ b/src/lib/helper/jsonContentRequired.ts
@@ -1,0 +1,10 @@
+import { jsonContent } from './jsonContent'
+import type { ZodSchema } from './types'
+
+export const jsonContentRequired = <T extends ZodSchema>(
+  schema: T,
+  description: string
+) => ({
+  ...jsonContent<T>(schema, description),
+  required: true,
+})

--- a/src/lib/helper/types.d.ts
+++ b/src/lib/helper/types.d.ts
@@ -1,0 +1,3 @@
+import type { z } from '@hono/zod-openapi'
+
+export type ZodSchema = z.ZodUnion | z.AnyZodObject | z.ZodArray<z.AnyZodObject>

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -5,7 +5,10 @@ import { sign, verify } from 'hono/jwt'
 const JWT_SECRET = 'my-secret'
 
 // generate a JWT token
-export const generateJWT = async (c: Context, payload: Record<string, any>) => {
+export const generateJWT = async (
+  c: Context,
+  payload: Record<string, unknown>
+) => {
   return await sign(payload, c.env.JWT_SECRET)
 }
 
@@ -13,7 +16,7 @@ export const generateJWT = async (c: Context, payload: Record<string, any>) => {
 export const verifyJWT = async (c: Context, token: string) => {
   try {
     return await verify(token, JWT_SECRET)
-  } catch (error: any) {
+  } catch (error: unknown) {
     if (error instanceof Error && error.name === 'TokenExpiredError') {
       return c.json(
         { error: 'Token expired', message: 'Please log in again' },

--- a/src/utils/passwordValidator.test.ts
+++ b/src/utils/passwordValidator.test.ts
@@ -1,6 +1,6 @@
+import { passwordValidator } from '@/utils/passwordValidator'
 import type { Context } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
-import { passwordValidator } from './passwordValidator'
 
 // Mock database preparation function
 const mockDB = {

--- a/src/utils/passwordValidator.ts
+++ b/src/utils/passwordValidator.ts
@@ -25,6 +25,11 @@ export const passwordValidator = async (
     return `Password must be at least ${passwordRule.min_length} characters long`
   }
 
+  // Hard rule: must less than 64 characters
+  if (password.length > 64) {
+    return 'Password cannot exceed 64 characters'
+  }
+
   const typeChecks = [
     { regex: /[a-z]/, required: false, message: 'lowercase letter' },
     {

--- a/src/utils/passwordValidator.ts
+++ b/src/utils/passwordValidator.ts
@@ -1,3 +1,4 @@
+import { getPasswordRoleByUserRoleId } from '@/lib/db'
 import type { Context } from 'hono'
 
 export const passwordValidator = async (
@@ -5,16 +6,7 @@ export const passwordValidator = async (
   password: string,
   userRoleId: number = 1
 ) => {
-  const db = c.env.DB // Cloudflare D1
-  const passwordRule = await db
-    .prepare(
-      `SELECT min_length, min_type, require_special, require_upper, require_number
-       FROM PasswordRules
-       JOIN UserRoles ON UserRoles.password_rule_id = PasswordRules.id
-       WHERE UserRoles.id = ?`
-    )
-    .bind(userRoleId)
-    .first()
+  const passwordRule = await getPasswordRoleByUserRoleId(c.env.DB, userRoleId)
 
   if (!passwordRule) {
     throw new Error(`Password rule not found for user role: ${userRoleId}`)

--- a/src/utils/usernameValidator.test.ts
+++ b/src/utils/usernameValidator.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 const mockDB = {
   prepare: vi.fn().mockReturnThis(),
   bind: vi.fn().mockReturnThis(),
-  get: vi.fn(),
+  first: vi.fn(),
 }
 
 // Mock context
@@ -18,7 +18,7 @@ const mockContext = {
 
 describe('usernameValidator', () => {
   it('should pass with a valid username', async () => {
-    mockDB.get.mockResolvedValueOnce(null) // Username is not taken
+    mockDB.first.mockResolvedValueOnce(null) // Username is not taken
 
     const result = await usernameValidator(mockContext, 'valid_user')
 
@@ -26,7 +26,7 @@ describe('usernameValidator', () => {
   })
 
   it('should fail if username is already taken', async () => {
-    mockDB.get.mockResolvedValueOnce({ id: 1 }) // Username exists in DB
+    mockDB.first.mockResolvedValueOnce({ id: 1 }) // Username exists in DB
 
     const result = await usernameValidator(mockContext, 'taken_user')
 
@@ -34,7 +34,7 @@ describe('usernameValidator', () => {
   })
 
   it('should fail if username contains bad words', async () => {
-    mockDB.get.mockResolvedValueOnce(null) // Username is not taken
+    mockDB.first.mockResolvedValueOnce(null) // Username is not taken
 
     const result = await usernameValidator(mockContext, 'fuck_user')
 
@@ -42,7 +42,7 @@ describe('usernameValidator', () => {
   })
 
   it('should fail if username contains risky words', async () => {
-    mockDB.get.mockResolvedValueOnce(null) // Username is not taken
+    mockDB.first.mockResolvedValueOnce(null) // Username is not taken
 
     const result = await usernameValidator(mockContext, 'adminUser')
 
@@ -50,7 +50,7 @@ describe('usernameValidator', () => {
   })
 
   it('should fail if username contains reserved system words', async () => {
-    mockDB.get.mockResolvedValueOnce(null) // Username is not taken
+    mockDB.first.mockResolvedValueOnce(null) // Username is not taken
 
     const result = await usernameValidator(mockContext, 'system')
 
@@ -58,7 +58,7 @@ describe('usernameValidator', () => {
   })
 
   it('should fail if username is too short', async () => {
-    mockDB.get.mockResolvedValueOnce(null) // Username is not taken
+    mockDB.first.mockResolvedValueOnce(null) // Username is not taken
 
     const result = await usernameValidator(mockContext, 'usr')
 
@@ -66,7 +66,7 @@ describe('usernameValidator', () => {
   })
 
   it('should fail if username is too long', async () => {
-    mockDB.get.mockResolvedValueOnce(null) // Username is not taken
+    mockDB.first.mockResolvedValueOnce(null) // Username is not taken
 
     const result = await usernameValidator(
       mockContext,
@@ -77,7 +77,7 @@ describe('usernameValidator', () => {
   })
 
   it('should fail if username contains disallowed special characters', async () => {
-    mockDB.get.mockResolvedValueOnce(null) // Username is not taken
+    mockDB.first.mockResolvedValueOnce(null) // Username is not taken
 
     const result = await usernameValidator(mockContext, 'user@name')
 
@@ -87,7 +87,7 @@ describe('usernameValidator', () => {
   })
 
   it('should pass if username contains only allowed special characters', async () => {
-    mockDB.get.mockResolvedValueOnce(null) // Username is not taken
+    mockDB.first.mockResolvedValueOnce(null) // Username is not taken
 
     const result = await usernameValidator(mockContext, 'user-name')
 

--- a/src/utils/usernameValidator.test.ts
+++ b/src/utils/usernameValidator.test.ts
@@ -1,6 +1,6 @@
+import { usernameValidator } from '@/utils/usernameValidator'
 import type { Context } from 'hono'
 import { describe, expect, it, vi } from 'vitest'
-import { usernameValidator } from './usernameValidator'
 
 // Mock database preparation function
 const mockDB = {

--- a/src/utils/usernameValidator.ts
+++ b/src/utils/usernameValidator.ts
@@ -1,3 +1,4 @@
+import { getUserByUsername } from '@/lib/db'
 import { Filter } from 'bad-words'
 import type { Context } from 'hono'
 
@@ -41,13 +42,8 @@ const reservedSystemWords = [
 const filter = new Filter()
 
 export const usernameValidator = async (c: Context, username: string) => {
-  const db = c.env.DB // Cloudflare D1
-
   // Check if username is already taken
-  const existingUser = await db
-    .prepare(`SELECT user_id FROM users WHERE username = ?`)
-    .bind(username)
-    .first()
+  const existingUser = await getUserByUsername(c.env.DB, username)
 
   if (existingUser) {
     return `Username ${username} is already taken`

--- a/src/utils/usernameValidator.ts
+++ b/src/utils/usernameValidator.ts
@@ -45,9 +45,9 @@ export const usernameValidator = async (c: Context, username: string) => {
 
   // Check if username is already taken
   const existingUser = await db
-    .prepare(`SELECT id FROM users WHERE username = ?`)
+    .prepare(`SELECT user_id FROM users WHERE username = ?`)
     .bind(username)
-    .get()
+    .first()
 
   if (existingUser) {
     return `Username ${username} is already taken`

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,4 +1,4 @@
-import path from 'path'
+import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
@@ -6,10 +6,5 @@ export default defineConfig({
     reporters: process.env.GITHUB_ACTIONS ? ['dot', 'github-actions'] : ['dot'],
     globals: true,
   },
-  resolve: {
-    alias: {
-      hono: path.resolve(__dirname, '.yarn/$$virtual/hono-virtual-hono/jsx.js'),
-      '@': path.resolve(__dirname, 'src'),
-    },
-  },
+  plugins: [tsconfigPaths()],
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,6 +660,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@polka/url@npm:^1.0.0-next.24":
+  version: 1.0.0-next.28
+  resolution: "@polka/url@npm:1.0.0-next.28"
+  checksum: 10c0/acc5ea62597e4da2fb42dbee02749d07f102ae7d6d2c966bf7e423c79cd65d1621da305af567e6e7c232f3b565e242d1ec932cbb3dcc0db1508d02e9a2cafa2e
+  languageName: node
+  linkType: hard
+
 "@rollup/rollup-android-arm-eabi@npm:4.24.3":
   version: 4.24.3
   resolution: "@rollup/rollup-android-arm-eabi@npm:4.24.3"
@@ -822,6 +829,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~6.19.8"
   checksum: 10c0/5e43553026c83f18bfa381d35c8fd608e69d12d0f0fe4601e8bb98b651a3b240be9d66c1f2f4decdbebb41d55b18e89238b02f3992d820d89801b9b3625ba8ab
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^22.8.6":
+  version: 22.8.6
+  resolution: "@types/node@npm:22.8.6"
+  dependencies:
+    undici-types: "npm:~6.19.8"
+  checksum: 10c0/d3a11f2549234a91a4c5d0ff35ab4bdcb7ba34db4d3f1d189be39b8bd41c19aac98d117150a95a9c5a9d45b1014135477ea240b2b8317c86ae3d3cf1c3b3f8f4
   languageName: node
   linkType: hard
 
@@ -1008,6 +1024,23 @@ __metadata:
   dependencies:
     tinyspy: "npm:^3.0.2"
   checksum: 10c0/a983efa140fa5211dc96a0c7c5110883c8095d00c45e711ecde1cc4a862560055b0e24907ae55970ab4a034e52265b7e8e70168f0da4b500b448d3d214eb045e
+  languageName: node
+  linkType: hard
+
+"@vitest/ui@npm:2.1.4":
+  version: 2.1.4
+  resolution: "@vitest/ui@npm:2.1.4"
+  dependencies:
+    "@vitest/utils": "npm:2.1.4"
+    fflate: "npm:^0.8.2"
+    flatted: "npm:^3.3.1"
+    pathe: "npm:^1.1.2"
+    sirv: "npm:^3.0.0"
+    tinyglobby: "npm:^0.2.9"
+    tinyrainbow: "npm:^1.2.0"
+  peerDependencies:
+    vitest: 2.1.4
+  checksum: 10c0/28bb190a4a077b3511a19312bad06fdf526e0b6d216bc249df7d9f4d214106382da1b5ab1a6893153493150ca13fbeb42222fd4d90e9f41198401734d8662c2d
   languageName: node
   linkType: hard
 
@@ -1433,7 +1466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:~4.3.6":
+"debug@npm:4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.7, debug@npm:~4.3.6":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
   dependencies:
@@ -1947,6 +1980,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fdir@npm:^6.4.2":
+  version: 6.4.2
+  resolution: "fdir@npm:6.4.2"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: 10c0/34829886f34a3ca4170eca7c7180ec4de51a3abb4d380344063c0ae2e289b11d2ba8b724afee974598c83027fea363ff598caf2b51bc4e6b1e0d8b80cc530573
+  languageName: node
+  linkType: hard
+
+"fflate@npm:^0.8.2":
+  version: 0.8.2
+  resolution: "fflate@npm:0.8.2"
+  checksum: 10c0/03448d630c0a583abea594835a9fdb2aaf7d67787055a761515bf4ed862913cfd693b4c4ffd5c3f3b355a70cf1e19033e9ae5aedcca103188aaff91b8bd6e293
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -1985,7 +2037,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.2.9":
+"flatted@npm:^3.2.9, flatted@npm:^3.3.1":
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
   checksum: 10c0/324166b125ee07d4ca9bcf3a5f98d915d5db4f39d711fba640a3178b959919aae1f7cfd8aabcfef5826ed8aa8a2aa14cc85b2d7d18ff638ddf4ae3df39573eaf
@@ -2122,6 +2174,13 @@ __metadata:
   version: 15.11.0
   resolution: "globals@npm:15.11.0"
   checksum: 10c0/861e39bb6bd9bd1b9f355c25c962e5eb4b3f0e1567cf60fa6c06e8c502b0ec8706b1cce055d69d84d0b7b8e028bec5418cf629a54e7047e116538d1c1c1a375c
+  languageName: node
+  linkType: hard
+
+"globrex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "globrex@npm:0.1.2"
+  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
   languageName: node
   linkType: hard
 
@@ -2423,8 +2482,10 @@ __metadata:
     "@eslint/js": "npm:^9.13.0"
     "@hono/zod-openapi": "npm:^0.16.4"
     "@types/bcryptjs": "npm:^2"
+    "@types/node": "npm:^22.8.6"
     "@typescript-eslint/eslint-plugin": "npm:^8.12.2"
     "@typescript-eslint/parser": "npm:^8.12.2"
+    "@vitest/ui": "npm:2.1.4"
     bad-words: "npm:^4.0.0"
     bcryptjs: "npm:^2.4.3"
     eslint: "npm:^9.13.0"
@@ -2437,6 +2498,8 @@ __metadata:
     prettier: "npm:3.3.3"
     prettier-plugin-organize-imports: "npm:^4.1.0"
     typescript: "npm:^5.6.3"
+    vite: "npm:^5.4.10"
+    vite-tsconfig-paths: "npm:^5.0.1"
     vitest: "npm:^2.1.4"
     wrangler: "npm:^3.84.1"
     zod: "npm:^3.23.8"
@@ -2755,6 +2818,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mrmime@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mrmime@npm:2.0.0"
+  checksum: 10c0/312b35ed288986aec90955410b21ed7427fd1e4ee318cb5fc18765c8d029eeded9444faa46589e5b1ed6b35fb2054a802ac8dcb917ddf6b3e189cb3bf11a965c
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -3009,6 +3079,13 @@ __metadata:
   version: 2.3.1
   resolution: "picomatch@npm:2.3.1"
   checksum: 10c0/26c02b8d06f03206fc2ab8d16f19960f2ff9e81a658f831ecb656d8f17d9edc799e8364b1f4a7873e89d9702dff96204be0fa26fe4181f6843f040f819dac4be
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "picomatch@npm:4.0.2"
+  checksum: 10c0/7c51f3ad2bb42c776f49ebf964c644958158be30d0a510efd5a395e8d49cb5acfed5b82c0c5b365523ce18e6ab85013c9ebe574f60305892ec3fa8eee8304ccc
   languageName: node
   linkType: hard
 
@@ -3352,6 +3429,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sirv@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "sirv@npm:3.0.0"
+  dependencies:
+    "@polka/url": "npm:^1.0.0-next.24"
+    mrmime: "npm:^2.0.0"
+    totalist: "npm:^3.0.0"
+  checksum: 10c0/282c52ee5a93cafa297096ad31aa6c3004a21d4c93abe728b701e51e4329acb887f6e92f07696225414fd6bb4a7782fd64a42d0b6b6467ae0f66bd3fde90b865
+  languageName: node
+  linkType: hard
+
 "slice-ansi@npm:^5.0.0":
   version: 5.0.0
   resolution: "slice-ansi@npm:5.0.0"
@@ -3601,6 +3689,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinyglobby@npm:^0.2.9":
+  version: 0.2.10
+  resolution: "tinyglobby@npm:0.2.10"
+  dependencies:
+    fdir: "npm:^6.4.2"
+    picomatch: "npm:^4.0.2"
+  checksum: 10c0/ce946135d39b8c0e394e488ad59f4092e8c4ecd675ef1bcd4585c47de1b325e61ec6adfbfbe20c3c2bfa6fd674c5b06de2a2e65c433f752ae170aff11793e5ef
+  languageName: node
+  linkType: hard
+
 "tinypool@npm:^1.0.1":
   version: 1.0.1
   resolution: "tinypool@npm:1.0.1"
@@ -3631,12 +3729,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"totalist@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "totalist@npm:3.0.1"
+  checksum: 10c0/4bb1fadb69c3edbef91c73ebef9d25b33bbf69afe1e37ce544d5f7d13854cda15e47132f3e0dc4cafe300ddb8578c77c50a65004d8b6e97e77934a69aa924863
+  languageName: node
+  linkType: hard
+
 "ts-api-utils@npm:^1.3.0":
   version: 1.4.0
   resolution: "ts-api-utils@npm:1.4.0"
   peerDependencies:
     typescript: ">=4.2.0"
   checksum: 10c0/1b2bfa50ea52771d564bb143bb69010d25cda03ed573095fbac9b86f717012426443af6647e00e3db70fca60360482a30c1be7cf73c3521c321f6bf5e3594ea0
+  languageName: node
+  linkType: hard
+
+"tsconfck@npm:^3.0.3":
+  version: 3.1.4
+  resolution: "tsconfck@npm:3.1.4"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 10c0/5120e91b3388574b449d57d08f45d05d9966cf4b9d6aa1018652c1fff6d7d37b1ed099b07e6ebf6099aa40b8a16968dd337198c55b7274892849112b942861ed
   languageName: node
   linkType: hard
 
@@ -3752,7 +3871,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0":
+"vite-tsconfig-paths@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "vite-tsconfig-paths@npm:5.0.1"
+  dependencies:
+    debug: "npm:^4.1.1"
+    globrex: "npm:^0.1.2"
+    tsconfck: "npm:^3.0.3"
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 10c0/3c68a4d5df21ed4ef81749c20e91c5978989ed06bffc01688b3f1a0fe65951b461a68f0c017ad930a088cfe7a8cc04d0c8d955dfb8719d5edc7fb0ba9bf38a73
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0, vite@npm:^5.4.10":
   version: 5.4.10
   resolution: "vite@npm:5.4.10"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,6 +793,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scalar/hono-api-reference@npm:^0.5.158":
+  version: 0.5.158
+  resolution: "@scalar/hono-api-reference@npm:0.5.158"
+  dependencies:
+    "@scalar/types": "npm:0.0.18"
+  peerDependencies:
+    hono: ^4.0.0
+  checksum: 10c0/69c070a7d0147061ca7ddd17c7d374f2d37e2deb532383fee8ae55cda09f863b92049b0e278fecbf795d1dd9e9d37ec00f4a3e69acefe4604a34fe19207a8bbf
+  languageName: node
+  linkType: hard
+
+"@scalar/openapi-types@npm:0.1.4":
+  version: 0.1.4
+  resolution: "@scalar/openapi-types@npm:0.1.4"
+  checksum: 10c0/999a1f797f1ee33b5fb110ba7d545ea6c36cb34005cc065f2a438612dc8e74a929a06e69520a2a91a93e7da75bee30e6ae5c1359f6c76632a03f39f4ef514378
+  languageName: node
+  linkType: hard
+
+"@scalar/types@npm:0.0.18":
+  version: 0.0.18
+  resolution: "@scalar/types@npm:0.0.18"
+  dependencies:
+    "@scalar/openapi-types": "npm:0.1.4"
+    "@unhead/schema": "npm:^1.9.5"
+  checksum: 10c0/c45f2917e8e5ef641b623f23b664dcf545b4d9ecb232105714d51d0c0f803a2a9fdb52f94938ab8effe8e80a713138ae162d8d78648ae7dbe0b84de50f6bbea5
+  languageName: node
+  linkType: hard
+
 "@types/bcryptjs@npm:^2":
   version: 2.4.6
   resolution: "@types/bcryptjs@npm:2.4.6"
@@ -954,6 +982,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.12.2"
     eslint-visitor-keys: "npm:^3.4.3"
   checksum: 10c0/1f770d361bcb03ed028e5589824f6c7ba364da59fe8b982c2fed0878ad25890d80ebd6c72618ab5149317501964b7db106e20834179d4aa707a8cbffcca89d08
+  languageName: node
+  linkType: hard
+
+"@unhead/schema@npm:^1.9.5":
+  version: 1.11.10
+  resolution: "@unhead/schema@npm:1.11.10"
+  dependencies:
+    hookable: "npm:^5.5.3"
+    zhead: "npm:^2.2.4"
+  checksum: 10c0/b381a9d43967403f071cdda5d2c83aa1d98a7fe6696196c3cd287f71c6616dfd961632c45a337e24880041e1ac5789dac1e923d7ec0497912b55dfe7122ffde0
   languageName: node
   linkType: hard
 
@@ -2221,6 +2259,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hookable@npm:^5.5.3":
+  version: 5.5.3
+  resolution: "hookable@npm:5.5.3"
+  checksum: 10c0/275f4cc84d27f8d48c5a5cd5685b6c0fea9291be9deea5bff0cfa72856ed566abde1dcd8cb1da0f9a70b4da3d7ec0d60dc3554c4edbba647058cc38816eced3d
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -2481,6 +2526,7 @@ __metadata:
     "@cloudflare/workers-types": "npm:^4.20241022.0"
     "@eslint/js": "npm:^9.13.0"
     "@hono/zod-openapi": "npm:^0.16.4"
+    "@scalar/hono-api-reference": "npm:^0.5.158"
     "@types/bcryptjs": "npm:^2"
     "@types/node": "npm:^22.8.6"
     "@typescript-eslint/eslint-plugin": "npm:^8.12.2"
@@ -4181,6 +4227,13 @@ __metadata:
     mustache: "npm:^4.2.0"
     stacktracey: "npm:^2.1.8"
   checksum: 10c0/ab573c7dccebdaf2d6b084d262d5bfb22ad5c049fb1ad3e2d6a840af851042dd3a8a072665c5a5ee73c75bbc1618fbc08f1371ac896e54556bced0ddf996b026
+  languageName: node
+  linkType: hard
+
+"zhead@npm:^2.2.4":
+  version: 2.2.4
+  resolution: "zhead@npm:2.2.4"
+  checksum: 10c0/3d166fb661f1b7fdf8a0ef2222d9e574ab241e72141f2f1fda62a9250ca73aabf2eaf0d66046a3984cd24d1dd9bac231338c6271684d6b8caa6b66af7c45f275
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,17 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@asteasolutions/zod-to-openapi@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "@asteasolutions/zod-to-openapi@npm:7.2.0"
+  dependencies:
+    openapi3-ts: "npm:^4.1.2"
+  peerDependencies:
+    zod: ^3.20.2
+  checksum: 10c0/f9f571c94ff7cf0da4be0e84f6a8b9db4e36bfe950f31b91631b4db881cb8391e1b2bc278e97b2acfd42c6db34630e10581e647adc1e907bc44766bec07b677c
+  languageName: node
+  linkType: hard
+
 "@cloudflare/kv-asset-handler@npm:0.3.4":
   version: 0.3.4
   resolution: "@cloudflare/kv-asset-handler@npm:0.3.4"
@@ -491,6 +502,29 @@ __metadata:
   version: 2.1.1
   resolution: "@fastify/busboy@npm:2.1.1"
   checksum: 10c0/6f8027a8cba7f8f7b736718b013f5a38c0476eea67034c94a0d3c375e2b114366ad4419e6a6fa7ffc2ef9c6d3e0435d76dd584a7a1cbac23962fda7650b579e3
+  languageName: node
+  linkType: hard
+
+"@hono/zod-openapi@npm:^0.16.4":
+  version: 0.16.4
+  resolution: "@hono/zod-openapi@npm:0.16.4"
+  dependencies:
+    "@asteasolutions/zod-to-openapi": "npm:^7.1.0"
+    "@hono/zod-validator": "npm:0.3.0"
+  peerDependencies:
+    hono: ">=4.3.6"
+    zod: 3.*
+  checksum: 10c0/23352bcb9ab570403713ce8ab9427d8dfd8dce79f2034e45086a07192550968e8a0c5c284eb849130710106d72899ebd29316280663a3e5233d8f892edcfcd22
+  languageName: node
+  linkType: hard
+
+"@hono/zod-validator@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@hono/zod-validator@npm:0.3.0"
+  peerDependencies:
+    hono: ">=3.9.0"
+    zod: ^3.19.1
+  checksum: 10c0/0c33f99bec89aa5bf042e1d490b894044b60db98d9d7b1d9586ee2d4855a72b216a0101c4549118e7c7643acf12237c716a27c1849f07276dccb8e0be362a63e
   languageName: node
   linkType: hard
 
@@ -2387,6 +2421,7 @@ __metadata:
   dependencies:
     "@cloudflare/workers-types": "npm:^4.20241022.0"
     "@eslint/js": "npm:^9.13.0"
+    "@hono/zod-openapi": "npm:^0.16.4"
     "@types/bcryptjs": "npm:^2"
     "@typescript-eslint/eslint-plugin": "npm:^8.12.2"
     "@typescript-eslint/parser": "npm:^8.12.2"
@@ -2404,6 +2439,7 @@ __metadata:
     typescript: "npm:^5.6.3"
     vitest: "npm:^2.1.4"
     wrangler: "npm:^3.84.1"
+    zod: "npm:^3.23.8"
   languageName: unknown
   linkType: soft
 
@@ -2834,6 +2870,15 @@ __metadata:
   dependencies:
     mimic-function: "npm:^5.0.0"
   checksum: 10c0/5cb9179d74b63f52a196a2e7037ba2b9a893245a5532d3f44360012005c9cadb60851d56716ebff18a6f47129dab7168022445df47c2aff3b276d92585ed1221
+  languageName: node
+  linkType: hard
+
+"openapi3-ts@npm:^4.1.2":
+  version: 4.4.0
+  resolution: "openapi3-ts@npm:4.4.0"
+  dependencies:
+    yaml: "npm:^2.5.0"
+  checksum: 10c0/900b834279fc8a43c545728ad75ec7c26934ec5344225b60d1e1c0df44d742d7e7379aea18d9034e03031f079d3308ba5a68600682eece3ed41cdbdd10346a9e
   languageName: node
   linkType: hard
 
@@ -3968,6 +4013,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.5.0":
+  version: 2.6.0
+  resolution: "yaml@npm:2.6.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/9e74cdb91cc35512a1c41f5ce509b0e93cc1d00eff0901e4ba831ee75a71ddf0845702adcd6f4ee6c811319eb9b59653248462ab94fa021ab855543a75396ceb
+  languageName: node
+  linkType: hard
+
 "yaml@npm:~2.5.0":
   version: 2.5.1
   resolution: "yaml@npm:2.5.1"
@@ -3995,7 +4049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.22.3":
+"zod@npm:^3.22.3, zod@npm:^3.23.8":
   version: 3.23.8
   resolution: "zod@npm:3.23.8"
   checksum: 10c0/8f14c87d6b1b53c944c25ce7a28616896319d95bc46a9660fe441adc0ed0a81253b02b5abdaeffedbeb23bdd25a0bf1c29d2c12dd919aef6447652dd295e3e69


### PR DESCRIPTION
Code:
1. 4xx 5xx responses are now { { error: message }, statusCode }
2. 2xx responses are now { { data_json }, 2xx }

New Structure:
1. index.ts: entry changed to OpenAPIHono() from Hono()
1. lib/db: All query.
2. lib/helper: for zod json/response/response structures.

Test:
1. register test.

Fix:
1. register logic to check database query status from db feedback.

Dependencies:
1. Use [zod-openai](https://hono.dev/examples/zod-openapi) middleware for doc generating. (at /doc)
4. Use [scalar](https://github.com/scalar/scalar/blob/main/packages/hono-api-reference/README.md) for interactive API reference. (at /reference)
5. Add vite and vite-tsconfig-path as dev-dependencies for alias resolving.