### PR TITLE
refactor(auth): integrate Hono's JWT middleware and expand payload info

### DIFF
--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -49,15 +49,12 @@ export const loginHandler = async (c: Context) => {
   }
 
   // Generate a JWT token and set it as a cookie
-  const catchError = await generateAuthTokenAndSetCookie(
-    c,
-    user.user_id,
-    user.user_role_id
-  )
-
-  if (catchError) {
-    return c.json(catchError, 500)
-  }
+  await generateAuthTokenAndSetCookie(c, {
+    user_id: user.user_id,
+    username: user.username,
+    user_role_id: user.user_role_id,
+    created_at: user.created_at,
+  })
 
   return c.json({ message: 'Login successful' }, 200)
 }

--- a/src/auth/register.test.ts
+++ b/src/auth/register.test.ts
@@ -71,9 +71,9 @@ describe('registerHandler', () => {
 
     expect(mockContext.json).toHaveBeenCalledWith(
       {
-        id: 1,
+        user_id: 1,
         username: 'newUser',
-        role: 1,
+        user_role_id: 1,
       },
       201
     )

--- a/src/auth/register.ts
+++ b/src/auth/register.ts
@@ -67,21 +67,18 @@ export const registerHandler = async (c: Context) => {
   }
 
   // Generate a JWT token and set it as a cookie
-  const catchError = await generateAuthTokenAndSetCookie(
-    c,
-    user.user_id,
-    user.user_role_id
-  )
-
-  if (catchError) {
-    return c.json(catchError, 500)
-  }
+  await generateAuthTokenAndSetCookie(c, {
+    user_id: user.user_id,
+    username: user.username,
+    user_role_id: user.user_role_id,
+    created_at: user.created_at,
+  })
 
   return c.json(
     {
-      id: user.user_id,
+      user_id: user.user_id,
       username: user.username,
-      role: user.user_role_id,
+      user_role_id: user.user_role_id,
     },
     201
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,16 @@ import { workerLogger } from '@/middleware/worker-logger'
 import { OpenAPIHono } from '@hono/zod-openapi'
 import { apiReference } from '@scalar/hono-api-reference'
 import type { Context } from 'hono'
+import type { JwtVariables } from 'hono/jwt'
 
 type Bindings = {
   JWT_SECRET: string
   JWT_EXPIRE_IN: string
   CORS_CSRF_ORIGIN: string
 }
+type Variables = JwtVariables
 
-const app = new OpenAPIHono<{ Bindings: Bindings }>()
+const app = new OpenAPIHono<{ Bindings: Bindings; Variables: Variables }>()
 
 // Add worker logger middleware to all routes
 app.use(workerLogger)

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -1,31 +1,47 @@
+import { getUserByUserId } from '@/lib/db'
 import { errorResponse } from '@/lib/helper'
-import { validateAuthToken } from '@/utils/auth-token'
-import type { Context, Next } from 'hono'
-import { createMiddleware } from 'hono/factory'
+import { generateAuthTokenAndSetCookie } from '@/utils/auth-token'
+import type { Context, MiddlewareHandler, Next } from 'hono'
+import { HTTPException } from 'hono/http-exception'
+import { jwt } from 'hono/jwt'
 
 export const authMiddlewareSchema = {
-  401: errorResponse('Token expired'),
-  403: errorResponse('Invalid token'),
+  401: errorResponse('token verification failure'),
   404: errorResponse('User not found'),
-  500: errorResponse('Failed to generate JWT'),
+  500: errorResponse('Failed to refresh token'),
 }
 
-export const authMiddleware = createMiddleware(
-  async (c: Context, next: Next) => {
-    const result = await validateAuthToken(c)
+export const authMiddleware: MiddlewareHandler = async (
+  c: Context,
+  next: Next
+) => {
+  const jwtMiddleware = jwt({
+    secret: c.env.JWT_SECRET,
+    cookie: 'access_token',
+  })
 
-    if ('error' in result) {
-      return c.json({ error: result.error }, result.status)
+  await jwtMiddleware(c, async () => {
+    const payload = c.get('jwtPayload')
+    if (!payload || typeof payload.user_id !== 'number') {
+      throw new HTTPException(401, { message: 'Token verification failure' })
     }
 
-    // If validation is successful, carry the user's profile to context
-    c.set('user', {
-      user_id: result.user_id,
-      username: result.username,
-      user_role_id: result.user_role_id,
-      created_at: result.created_at,
-    })
+    const user = await getUserByUserId(c.env.DB, payload.user_id)
+    if (!user) {
+      throw new HTTPException(404, { message: 'User not found' })
+    }
+
+    const payloadToSign = {
+      user_id: user.user_id,
+      username: user.username,
+      user_role_id: user.user_role_id,
+      created_at: user.created_at,
+    }
+
+    await generateAuthTokenAndSetCookie(c, payloadToSign)
+
+    c.set('user', payloadToSign)
 
     await next()
-  }
-)
+  })
+}

--- a/src/middleware/on-error.ts
+++ b/src/middleware/on-error.ts
@@ -1,10 +1,14 @@
 import type { Context, ErrorHandler } from 'hono'
+import { HTTPException } from 'hono/http-exception'
 import type { HTTPResponseError } from 'hono/types'
 
 export const onError: ErrorHandler = (
   err: Error | HTTPResponseError,
   c: Context
 ) => {
-  console.error(`Error: ${err}`)
+  if (err instanceof HTTPException) {
+    // If the error is an instance of HTTPException, return the error message
+    return c.json({ error: err.message }, err.status)
+  }
   return c.json({ error: 'Internal Server Error' }, 500)
 }

--- a/src/utils/auth-token.ts
+++ b/src/utils/auth-token.ts
@@ -1,15 +1,19 @@
-import { getUserByUserId } from '@/lib/db'
 import type { Context } from 'hono'
-import { getSignedCookie, setSignedCookie } from 'hono/cookie'
-import { sign, verify } from 'hono/jwt'
-import * as JwtErrors from 'hono/utils/jwt/types'
-import type { ValidationResult } from './types'
+import { setSignedCookie } from 'hono/cookie'
+import { HTTPException } from 'hono/http-exception'
+import { sign } from 'hono/jwt'
+
+interface PayloadToSignInterface {
+  user_id: number
+  username: string
+  user_role_id: number
+  created_at: string
+}
 
 // Generate JWT token and set it as a cookie
 export const generateAuthTokenAndSetCookie = async (
   c: Context,
-  user_id: number,
-  user_role_id: number
+  payloadToSign: PayloadToSignInterface
 ): Promise<void | { error: string }> => {
   try {
     const exp =
@@ -20,8 +24,7 @@ export const generateAuthTokenAndSetCookie = async (
     const iat = Math.floor(Date.now() / 1000) - 24 * 60 * 60
 
     const payload = {
-      user_id,
-      user_role_id,
+      ...payloadToSign,
       exp: exp,
       nbf: nbf,
       iat: iat,
@@ -38,70 +41,6 @@ export const generateAuthTokenAndSetCookie = async (
       expires: new Date(exp * 1000),
     })
   } catch {
-    return { error: 'Failed to generate JWT' }
-  }
-}
-
-// Verify cookie and return user's profile
-// * If 'error' exists in result, handle as an error response
-export const validateAuthToken = async (
-  c: Context
-): Promise<ValidationResult> => {
-  const token = await getSignedCookie(c, c.env.JWT_SECRET, 'access_token')
-
-  if (!token) {
-    return { status: 401, error: 'Not logged in' }
-  }
-
-  try {
-    const decoded = await verify(token, c.env.JWT_SECRET)
-
-    if (!decoded || typeof decoded.user_id !== 'number') {
-      return { status: 403, error: 'Invalid token' }
-    }
-
-    const user = await getUserByUserId(c.env.DB, decoded.user_id)
-
-    if (!user) {
-      return { status: 404, error: 'User not found' }
-    }
-
-    const catchError = await generateAuthTokenAndSetCookie(
-      c,
-      user.user_id,
-      user.user_role_id
-    )
-
-    if (catchError) {
-      return { status: 500, error: 'Failed to refresh token' }
-    }
-
-    return {
-      user_id: user.user_id,
-      username: user.username,
-      user_role_id: user.user_role_id,
-      created_at: user.created_at,
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      // Use the JwtErrors namespace to access each error type
-      switch (error.constructor) {
-        case JwtErrors.JwtTokenExpired:
-          return { status: 401, error: 'Token expired' }
-        case JwtErrors.JwtTokenInvalid:
-          return { status: 403, error: 'Invalid token' }
-        case JwtErrors.JwtTokenNotBefore:
-          return { status: 403, error: 'Token not valid yet' }
-        case JwtErrors.JwtTokenIssuedAt:
-          return { status: 403, error: 'Incorrect token issue date' }
-        case JwtErrors.JwtTokenSignatureMismatched:
-          return { status: 403, error: 'Token signature mismatch' }
-        case JwtErrors.JwtAlgorithmNotImplemented:
-          return { status: 500, error: 'Algorithm not implemented' }
-        default:
-          return { status: 403, error: 'Token verification failed' }
-      }
-    }
-    return { status: 403, error: 'Token verification failed' }
+    throw new HTTPException(500, { message: 'Failed to refresh token' })
   }
 }


### PR DESCRIPTION
- Replaced custom `validateAuthToken` logic in `auth-token` with Hono's JWT middleware for streamlined token validation and decoding.
- Expanded JWT payload to include `username` and `created_at` fields for better reusability, reducing the need for repetitive database calls.
- Updated `auth-middleware` to handle decoded payload, simplifying data access.

- Future improvements: Consider implementing payload refresh within the middleware to optimize database access frequency.